### PR TITLE
Ensure output meets print spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,6 @@ Run the generator:
 python3 generate_cards.py cards.csv output_cards
 ```
 
-Generated PNG images will be placed in `output_cards/`.
+Generated JPEG images suitable for printing will be placed in `output_cards/`.
+The output images are CMYK JPEG files at 300 DPI, sized 69×94 mm (including
+3 mm bleed on each side).

--- a/generate_cards.py
+++ b/generate_cards.py
@@ -2,8 +2,15 @@ import csv
 import os
 from PIL import Image, ImageDraw, ImageFont
 
-CARD_WIDTH = 744
-CARD_HEIGHT = 1039
+# Trimmed card size (63x88mm at 300 DPI)
+TRIM_WIDTH = 744
+TRIM_HEIGHT = 1039
+
+# Full card size including 3mm bleed on each side (69x94mm at 300 DPI)
+BLEED = 35  # ~3mm
+CARD_WIDTH = TRIM_WIDTH + BLEED * 2 + 1
+CARD_HEIGHT = TRIM_HEIGHT + BLEED * 2 + 1
+DPI = 300
 
 COLOR_MAP = {
     'white': '#e6e6e6',
@@ -13,8 +20,14 @@ COLOR_MAP = {
     'green': '#99ff99'
 }
 
-TITLE_FONT = os.environ.get("TITLE_FONT", "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf")
-TEXT_FONT = os.environ.get("TEXT_FONT", "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf")
+TITLE_FONT = os.environ.get(
+    "TITLE_FONT",
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+)
+TEXT_FONT = os.environ.get(
+    "TEXT_FONT",
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+)
 
 
 def load_font(path: str, size: int) -> ImageFont.FreeTypeFont:
@@ -24,35 +37,48 @@ def load_font(path: str, size: int) -> ImageFont.FreeTypeFont:
     except OSError:
         return ImageFont.load_default()
 
+
 def draw_card(card: dict, output_dir: str) -> None:
     """Render a single card as an image and save it to *output_dir*."""
     if not os.path.exists(card['art_file']):
         raise FileNotFoundError(card['art_file'])
+
     art = Image.open(card['art_file']).convert('RGBA')
-    card_img = Image.new('RGBA', (CARD_WIDTH, CARD_HEIGHT), 'white')
-    draw = ImageDraw.Draw(card_img)
+
+    # Draw the trimmed area first and then place it on a larger canvas
+    trimmed = Image.new('RGBA', (TRIM_WIDTH, TRIM_HEIGHT), 'white')
+    draw = ImageDraw.Draw(trimmed)
 
     title_font = load_font(TITLE_FONT, 40)
     text_font = load_font(TEXT_FONT, 24)
 
     border_color = COLOR_MAP.get(card['color'].lower(), 'white')
-    draw.rectangle([0, 0, CARD_WIDTH-1, CARD_HEIGHT-1], outline=border_color, width=12)
+    draw.rectangle(
+        [0, 0, TRIM_WIDTH - 1, TRIM_HEIGHT - 1],
+        outline=border_color,
+        width=12,
+    )
 
-    draw.rectangle([20, 20, CARD_WIDTH-20, 90], fill=border_color)
+    draw.rectangle([20, 20, TRIM_WIDTH-20, 90], fill=border_color)
     draw.text((30, 30), card['name'], font=title_font, fill='black')
-    draw.text((CARD_WIDTH-150, 30), card['cost'], font=title_font, fill='black')
+    draw.text(
+        (TRIM_WIDTH - 150, 30),
+        card['cost'],
+        font=title_font,
+        fill='black',
+    )
 
     art_area_height = 520
-    art_target_width = CARD_WIDTH - 40
+    art_target_width = TRIM_WIDTH - 40
     art_target_height = art_area_height
     ratio = min(art_target_width / art.width, art_target_height / art.height)
     resized = art.resize((int(art.width*ratio), int(art.height*ratio)))
-    art_x = (CARD_WIDTH - resized.width) // 2
+    art_x = (TRIM_WIDTH - resized.width) // 2
     art_y = 110 + (art_target_height - resized.height)//2
-    card_img.paste(resized, (art_x, art_y))
+    trimmed.paste(resized, (art_x, art_y))
 
     text_y = 110 + art_area_height + 20
-    text_box = [20, text_y, CARD_WIDTH-20, CARD_HEIGHT-110]
+    text_box = [20, text_y, TRIM_WIDTH-20, TRIM_HEIGHT-110]
     draw.rectangle(text_box, fill='white')
     if card['type'].lower() == 'creature':
         desc = f"Strength: {card['strength']}"
@@ -60,10 +86,15 @@ def draw_card(card: dict, output_dir: str) -> None:
         desc = card['description']
     draw.multiline_text((30, text_y+10), desc, font=text_font, fill='black')
 
-    out_name = f"{card['name'].replace(' ', '_')}.png"
+    # Place trimmed artwork on a larger canvas for bleed
+    card_img = Image.new('CMYK', (CARD_WIDTH, CARD_HEIGHT), 'white')
+    card_img.paste(trimmed.convert('CMYK'), (BLEED, BLEED))
+
+    out_name = f"{card['name'].replace(' ', '_')}.jpg"
     out_path = os.path.join(output_dir, out_name)
-    card_img.convert('RGB').save(out_path)
+    card_img.save(out_path, 'JPEG', dpi=(DPI, DPI))
     print('Saved', out_path)
+
 
 def main(csv_path, output_dir):
     os.makedirs(output_dir, exist_ok=True)
@@ -71,6 +102,7 @@ def main(csv_path, output_dir):
         reader = csv.DictReader(f)
         for row in reader:
             draw_card(row, output_dir)
+
 
 if __name__ == '__main__':
     import sys


### PR DESCRIPTION
## Summary
- update generate_cards script to produce 69x94mm cards with 3mm bleed
- save cards as CMYK JPEGs at 300 DPI
- document JPEG output with print size
- fix style issues and pass flake8

## Testing
- `flake8 generate_cards.py`


------
https://chatgpt.com/codex/tasks/task_e_687bf3218830832197057eb5be373ce4