### PR TITLE
Improve card layout using frame assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Card Generator
 
-This repository contains a small tool for generating printable card images from a CSV file.
+This repository contains a small tool for generating printable card images from
+a CSV file using Pillow. Card frames and fonts must be supplied separately (see
+`assets/README.md`).
 
 ## Requirements
 
@@ -12,16 +14,18 @@ This repository contains a small tool for generating printable card images from 
 Prepare a CSV file with the following columns:
 
 ```
-name,cost,type,color,art_file,strength,description
+name,cost,type,subtype,color,art_file,stregth,description
 ```
 
 - **name**: Card name
-- **cost**: Mana or resource cost (e.g., `2W`)
-- **type**: `creature` or `spell`
-- **color**: `white`, `blue`, `black`, `red`, or `green`
-- **art_file**: Path to the artwork image
-- **strength**: Strength value for creatures
-- **description**: Text description for spells
+- **cost**: Mana or resource cost (e.g., `{2}{R}`)
+- **type**: `Creature` or `Spell`
+- **subtype**: Subtype or rules text header
+- **color**: Card colour; determines which frame is used
+- **art_file**: Optional path to artwork image. If omitted, the script will
+  look for `art/<slugified name>.png`.
+- **stregth**: Strength value for creatures
+- **description**: Rules text for spells
 
 Run the generator:
 
@@ -29,6 +33,5 @@ Run the generator:
 python3 generate_cards.py cards.csv output_cards
 ```
 
-Generated JPEG images suitable for printing will be placed in `output_cards/`.
-The output images are CMYK JPEG files at 300 DPI, sized 69×94 mm (including
-3 mm bleed on each side).
+Generated TIFF images suitable for printing will be placed in `output_cards/`.
+The output files are CMYK TIFF images at 300 DPI sized 63×88 mm (no bleed).

--- a/assets/README.md
+++ b/assets/README.md
@@ -1,0 +1,15 @@
+# Assets Directory
+
+This folder should contain the graphical assets and fonts required by
+`generate_cards.py`.
+
+Expected files:
+
+- `frame_red.png`, `frame_blue.png`, `frame_black.png`, `frame_green.png`,
+  `frame_white.png` – card frames for each color in RGBA format.
+- `Beleren-Bold.ttf` – font used for card titles.
+- `MPlantin.ttf` – font used for rules text.
+- `MagicSymbols.ttf` – font providing mana and other icons.
+
+These files are not included in the repository. Supply your own copies before
+running the generator.

--- a/generate_cards.py
+++ b/generate_cards.py
@@ -1,112 +1,112 @@
 import csv
 import os
+import unicodedata
+from pathlib import Path
 from PIL import Image, ImageDraw, ImageFont
+import textwrap
 
-# Trimmed card size (63x88mm at 300 DPI)
-TRIM_WIDTH = 744
-TRIM_HEIGHT = 1039
-
-# Full card size including 3mm bleed on each side (69x94mm at 300 DPI)
-BLEED = 35  # ~3mm
-CARD_WIDTH = TRIM_WIDTH + BLEED * 2 + 1
-CARD_HEIGHT = TRIM_HEIGHT + BLEED * 2 + 1
 DPI = 300
+CARD_W, CARD_H = (744, 1039)  # 63x88 mm trimmed
 
-COLOR_MAP = {
-    'white': '#e6e6e6',
-    'blue': '#99ccff',
-    'black': '#404040',
-    'red': '#ff9999',
-    'green': '#99ff99'
-}
+# Layout coordinates (match the frame assets)
+ART_BOX = (64, 164, 680, 650)
+TITLE_ORIGIN = (92, 98)
+COST_ORIGIN = (600, 100)
+TEXT_BOX = (92, 700, 652, 960)
 
-TITLE_FONT = os.environ.get(
-    "TITLE_FONT",
-    "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
-)
-TEXT_FONT = os.environ.get(
-    "TEXT_FONT",
-    "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
-)
+ASSETS_DIR = Path("assets")
+TITLE_FONT_PATH = os.environ.get("TITLE_FONT", ASSETS_DIR / "Beleren-Bold.ttf")
+RULES_FONT_PATH = os.environ.get("RULES_FONT", ASSETS_DIR / "MPlantin.ttf")
+SYMBOL_FONT_PATH = os.environ.get("SYMBOL_FONT", ASSETS_DIR / "MagicSymbols.ttf")
 
 
-def load_font(path: str, size: int) -> ImageFont.FreeTypeFont:
+def load_font(path: str | Path, size: int) -> ImageFont.FreeTypeFont:
     """Load a font, falling back to the default if the file is missing."""
     try:
-        return ImageFont.truetype(path, size)
+        return ImageFont.truetype(str(path), size)
     except OSError:
         return ImageFont.load_default()
 
 
-def draw_card(card: dict, output_dir: str) -> None:
-    """Render a single card as an image and save it to *output_dir*."""
-    if not os.path.exists(card['art_file']):
-        raise FileNotFoundError(card['art_file'])
+def fit_into(box, img: Image.Image) -> Image.Image:
+    """Resize *img* to cover ``box`` while preserving aspect ratio."""
+    bw, bh = box[2] - box[0], box[3] - box[1]
+    ratio = min(bw / img.width, bh / img.height)
+    return img.resize((int(img.width * ratio), int(img.height * ratio)), Image.LANCZOS)
 
-    art = Image.open(card['art_file']).convert('RGBA')
 
-    # Draw the trimmed area first and then place it on a larger canvas
-    trimmed = Image.new('RGBA', (TRIM_WIDTH, TRIM_HEIGHT), 'white')
-    draw = ImageDraw.Draw(trimmed)
+def slugify(name: str) -> str:
+    """Return an ASCII file name derived from ``name``."""
+    nfkd = unicodedata.normalize("NFKD", name)
+    ascii_name = "".join(c for c in nfkd if not unicodedata.combining(c))
+    return "".join(ch for ch in ascii_name if ch.isalnum()).lower()
 
-    title_font = load_font(TITLE_FONT, 40)
-    text_font = load_font(TEXT_FONT, 24)
 
-    border_color = COLOR_MAP.get(card['color'].lower(), 'white')
-    draw.rectangle(
-        [0, 0, TRIM_WIDTH - 1, TRIM_HEIGHT - 1],
-        outline=border_color,
-        width=12,
+def resolve_art_file(card: dict) -> Path:
+    """Determine the artwork path for a card."""
+    if card.get("art_file") and Path(card["art_file"]).exists():
+        return Path(card["art_file"])
+    slug = slugify(card["name"])
+    for ext in (".png", ".jpg", ".jpeg"):  # search in art folder
+        candidate = Path("art") / f"{slug}{ext}"
+        if candidate.exists():
+            return candidate
+    raise FileNotFoundError(f"Artwork not found for {card['name']}")
+
+
+def draw_card(card: dict, out_dir: str) -> None:
+    color = card.get("color", "").lower()
+    frame_path = ASSETS_DIR / f"frame_{color}.png"
+    if not frame_path.exists():
+        frame_path = ASSETS_DIR / "frame.png"
+    FRAME = Image.open(frame_path).convert("RGBA") if frame_path.exists() else Image.new(
+        "RGBA", (CARD_W, CARD_H), "white"
     )
 
-    draw.rectangle([20, 20, TRIM_WIDTH-20, 90], fill=border_color)
-    draw.text((30, 30), card['name'], font=title_font, fill='black')
-    draw.text(
-        (TRIM_WIDTH - 150, 30),
-        card['cost'],
-        font=title_font,
-        fill='black',
-    )
+    canvas = Image.new("RGBA", (CARD_W, CARD_H), (0, 0, 0, 0))
+    canvas.paste(FRAME, (0, 0), FRAME)
 
-    art_area_height = 520
-    art_target_width = TRIM_WIDTH - 40
-    art_target_height = art_area_height
-    ratio = min(art_target_width / art.width, art_target_height / art.height)
-    resized = art.resize((int(art.width*ratio), int(art.height*ratio)))
-    art_x = (TRIM_WIDTH - resized.width) // 2
-    art_y = 110 + (art_target_height - resized.height)//2
-    trimmed.paste(resized, (art_x, art_y))
+    art_img = Image.open(resolve_art_file(card)).convert("RGBA")
+    art_img = fit_into(ART_BOX, art_img)
+    ax = ART_BOX[0] + (ART_BOX[2] - ART_BOX[0] - art_img.width) // 2
+    ay = ART_BOX[1] + (ART_BOX[3] - ART_BOX[1] - art_img.height) // 2
+    canvas.paste(art_img, (ax, ay), art_img)
 
-    text_y = 110 + art_area_height + 20
-    text_box = [20, text_y, TRIM_WIDTH-20, TRIM_HEIGHT-110]
-    draw.rectangle(text_box, fill='white')
-    if card['type'].lower() == 'creature':
-        desc = f"Strength: {card['strength']}"
+    draw = ImageDraw.Draw(canvas)
+    title_font = load_font(TITLE_FONT_PATH, 48)
+    rules_font = load_font(RULES_FONT_PATH, 34)
+    symbol_font = load_font(SYMBOL_FONT_PATH, 44)
+
+    draw.text(TITLE_ORIGIN, card["name"].upper(), font=title_font, fill="white", stroke_width=1, stroke_fill="black")
+    draw.text(COST_ORIGIN, card.get("cost", ""), font=symbol_font, fill="white", stroke_width=1, stroke_fill="black")
+
+    if card.get("type", "").lower() == "creature":
+        strength = card.get("stregth", "")
+        toughness = card.get("toughness", strength)
+        raw = f"{card.get('subtype', '')} — {strength}/{toughness}"
     else:
-        desc = card['description']
-    draw.multiline_text((30, text_y+10), desc, font=text_font, fill='black')
+        raw = card.get("description", "")
+    wrapped = "\n".join(textwrap.wrap(str(raw), width=38))
+    draw.multiline_text((TEXT_BOX[0], TEXT_BOX[1]), wrapped, font=rules_font, fill="black", spacing=4)
 
-    # Place trimmed artwork on a larger canvas for bleed
-    card_img = Image.new('CMYK', (CARD_WIDTH, CARD_HEIGHT), 'white')
-    card_img.paste(trimmed.convert('CMYK'), (BLEED, BLEED))
-
-    out_name = f"{card['name'].replace(' ', '_')}.jpg"
-    out_path = os.path.join(output_dir, out_name)
-    card_img.save(out_path, 'JPEG', dpi=(DPI, DPI))
-    print('Saved', out_path)
+    out_img = canvas.convert("CMYK")
+    out_path = Path(out_dir) / f"{slugify(card['name'])}.tif"
+    out_img.save(out_path, dpi=(DPI, DPI), compression="tiff_lzw")
+    print("Saved", out_path)
 
 
-def main(csv_path, output_dir):
-    os.makedirs(output_dir, exist_ok=True)
-    with open(csv_path, newline='', encoding='utf-8') as f:
+def main(csv_path: str, out_dir: str) -> None:
+    os.makedirs(out_dir, exist_ok=True)
+    with open(csv_path, newline="", encoding="utf-8") as f:
         reader = csv.DictReader(f)
         for row in reader:
-            draw_card(row, output_dir)
+            draw_card(row, out_dir)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     import sys
+
     if len(sys.argv) != 3:
-        print('Usage: python generate_cards.py <cards.csv> <output_dir>')
-        sys.exit(1)
+        print("Usage: python generate_cards.py <cards.csv> <output_dir>")
+        raise SystemExit(1)
     main(sys.argv[1], sys.argv[2])


### PR DESCRIPTION
## Summary
- update README with new usage details
- add documentation about external frame assets
- modernize `generate_cards.py` with frame-based rendering

## Testing
- `pip install Pillow`
- `python3 generate_cards.py test.csv out_test`

------
https://chatgpt.com/codex/tasks/task_e_687d916d265883219c490f31f47bf935